### PR TITLE
Update collection of longform entries

### DIFF
--- a/src/services/ReadtimeService.php
+++ b/src/services/ReadtimeService.php
@@ -48,7 +48,7 @@ class ReadtimeService extends Component
 
         if ($this->isCkEditor4Installed() && !empty($this->subEntryIds)) {
             // Find entries that are owned by the CKEditor fields.
-            $subEntries =  Entry::find()
+            $subEntries = Entry::find()
                 ->id($this->subEntryIds)
                 ->all();
 
@@ -73,7 +73,7 @@ class ReadtimeService extends Component
         return !ElementHelper::isDraftOrRevision($element) &&
             $this->elementHasReadtimeField($element);
     }
-    
+
     public function elementHasReadtimeField(ElementInterface $element): bool
     {
         return (bool) collect($element->getFieldLayout()?->getCustomFields())->firstWhere(
@@ -105,7 +105,7 @@ class ReadtimeService extends Component
             }
         } elseif ($this->isCKEditor($field)) {
             // Make sure content has not already been counted (Longform)
-            if( !in_array($element->id . "." . $field->handle, $this->excludeIds) ) {
+            if (!in_array($element->id . "." . $field->handle, $this->excludeIds)) {
                 $value = $field->serializeValue($element->getFieldValue($field->handle), $element);
                 $seconds = $this->valToSeconds($value);
                 $this->totalSeconds += $seconds;


### PR DESCRIPTION
# Description

Updated how CKEditor longform entry blocks are collected when looping through the fields.

The previous method of using the blocks' `ownerId` could also pull content from blocks that have been deleted from the editor. The content wouldn't be visible or accessible in the editor but it would inflate the calculated read time.